### PR TITLE
Remove TODOs to fix dumping issues on extenstion fields

### DIFF
--- a/pyopenapi/migration/versions/v2_0/scanner/upgrade/converters.py
+++ b/pyopenapi/migration/versions/v2_0/scanner/upgrade/converters.py
@@ -574,8 +574,11 @@ def to_path_item(obj, root_url, path, consumes=None, produces=None):
                 consumes=consumes)
 
     if body:
-        # TODO: this part would not be dumpped, so the dumpped
-        #       spec would be corrupted.
+        # Valid $ref for Parameter in Swagger 2.0 should only point
+        # to 'parameters' field under Swagger object, therefore, there
+        # should be no $ref point to here.
+        #
+        # This dumped field is only intended for debug only
         ret['x-pyopenapi_internal_request_body'] = body
 
     return ret, reloc


### PR DESCRIPTION
This field should not be referenced to, therefore is ok to:
 - not dump it, although we've made it dumpable.
 - it's not a necessary field, just a little bit helpful when debugging.